### PR TITLE
Update spring-ext repo

### DIFF
--- a/core/precalcmatches/server/pom.xml
+++ b/core/precalcmatches/server/pom.xml
@@ -19,7 +19,7 @@
         <repository>
             <id>spring-ext</id>
             <name>Spring External Dependencies Repository</name>
-            <url>https://springframework.svn.sourceforge.net/svnroot/springframework/repos/repo-ext/</url>
+            <url>https://svn.code.sf.net/p/springframework/svn/repos/repo-ext/</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
I'm getting some maven errors while [updating the conda package to 5.55-88.0](https://github.com/bioconda/bioconda-recipes/pull/34477), I suspect it comes from some sourceforge url being invalid (I get redirected when accessing https://springframework.svn.sourceforge.net/svnroot/springframework/repos/repo-ext/ in my browser, which must be confusing maven)