### PR TITLE
Fix hmmer SSI index failure for Superfamily and SFLD

### DIFF
--- a/core/io/src/main/java/uk/ac/ebi/interpro/scan/io/model/HmmerModelParser.java
+++ b/core/io/src/main/java/uk/ac/ebi/interpro/scan/io/model/HmmerModelParser.java
@@ -32,7 +32,11 @@ public class HmmerModelParser extends AbstractModelFileParser {
      * Matches the name line.
      * Group 1: Model name.
      */
-    private static final Pattern NAME_LINE = Pattern.compile("^NAME\\s+(.+)$");
+    // private static final Pattern NAME_LINE = Pattern.compile("^NAME\\s+(.+)$");
+
+    private static final Pattern NAME_LINE = Pattern.compile("^NAME\\s+(.*?)(?:\\$\\d+)?$");
+
+    // private static final Pattern NAME_LINE_SFLD = Pattern.compile("^NAME\\s+(.*?)(?:\\[\\d+\\])?$");
 
     /**
      * Matches the Description line.

--- a/core/io/src/main/java/uk/ac/ebi/interpro/scan/io/model/HmmerModelParser.java
+++ b/core/io/src/main/java/uk/ac/ebi/interpro/scan/io/model/HmmerModelParser.java
@@ -31,12 +31,11 @@ public class HmmerModelParser extends AbstractModelFileParser {
     /**
      * Matches the name line.
      * Group 1: Model name.
+     *
+     * NOTE: SFLD NAMEs may have '\$\d+' at end of string and this will be stripped off.
+     * This numbers are used to guarantee unique names.
      */
-    // private static final Pattern NAME_LINE = Pattern.compile("^NAME\\s+(.+)$");
-
     private static final Pattern NAME_LINE = Pattern.compile("^NAME\\s+(.*?)(?:\\$\\d+)?$");
-
-    // private static final Pattern NAME_LINE_SFLD = Pattern.compile("^NAME\\s+(.*?)(?:\\[\\d+\\])?$");
 
     /**
      * Matches the Description line.

--- a/core/io/src/main/java/uk/ac/ebi/interpro/scan/io/superfamily/model/SuperFamilyModelParser.java
+++ b/core/io/src/main/java/uk/ac/ebi/interpro/scan/io/superfamily/model/SuperFamilyModelParser.java
@@ -48,8 +48,8 @@ public class SuperFamilyModelParser extends AbstractModelFileParser {
     private static final Pattern DESC_LINE = Pattern.compile("^DESC\\s+(.+)$");
 
     /**
-     * Matches the signature accession line (but needs "SSF" prefix adding) and if there is a version number it will be
-     * stripped off (but doesn't really apply here).
+     * Matches the signature accession line (but needs "SSF" prefix adding) and if there is a 'version' number it will be
+     * stripped off. 'version' numbers are used to guarantee unique SuperFamily ACCs.
      */
     private static final Pattern ACCESSION_PATTERN = Pattern.compile("^ACC\\s+([A-Z0-9]+)\\.?.*$");
 

--- a/core/jms-implementation/src/main/resources/application-default.properties
+++ b/core/jms-implementation/src/main/resources/application-default.properties
@@ -78,12 +78,9 @@ binary.hmmer2.hmmsearch.path=${bin.directory}/hmmer/hmmer2/2.3.2/hmmsearch
 binary.hmmer2.hmmpfam.path=${bin.directory}/hmmer/hmmer2/2.3.2/hmmpfam
 
 # HMMER 3
-binary.hmmer3.path=${bin.directory}/hmmer/hmmer3/3.1b1
-binary.hmmer3.hmmscan.path=${bin.directory}/hmmer/hmmer3/3.1b1/hmmscan
-binary.hmmer3.hmmsearch.path=${bin.directory}/hmmer/hmmer3/3.1b1/hmmsearch
-binary.hmmer33.path=${bin.directory}/hmmer/hmmer3/3.3
-binary.hmmer33.hmmscan.path=${bin.directory}/hmmer/hmmer3/3.3/hmmscan
-binary.hmmer33.hmmsearch.path=${bin.directory}/hmmer/hmmer3/3.3/hmmsearch
+binary.hmmer3.path=${bin.directory}/hmmer/hmmer3/3.3
+binary.hmmer3.hmmscan.path=${bin.directory}/hmmer/hmmer3/3.3/hmmscan
+binary.hmmer3.hmmsearch.path=${bin.directory}/hmmer/hmmer3/3.3/hmmsearch
 
 # Misc
 binary.getorf.path=${bin.directory}/nucleotide/getorf

--- a/core/jms-implementation/src/main/resources/spring/jobs/jobAntiFam-context.xml
+++ b/core/jms-implementation/src/main/resources/spring/jobs/jobAntiFam-context.xml
@@ -39,7 +39,7 @@
         <property name="dependsUpon" ref="stepAntiFamWriteFastaFile"/>
         <property name="stepDescription" value="Run HMMER 3 Binary for selected proteins"/>
         <property name="fullPathToHmmScanBinary" value="${binary.hmmer3.hmmscan.path}"/>
-        <property name="fullPathToHmmsearchBinary" value="${binary.hmmer33.hmmsearch.path}"/>
+        <property name="fullPathToHmmsearchBinary" value="${binary.hmmer3.hmmsearch.path}"/>
         <property name="binarySwitches" value="${hmmer3.hmmsearch.switches.antifam} ${hmmer3.hmmsearch.cpu.switch.antifam}"/>
         <property name="usesFileOutputSwitch" value="true"/>
         <property name="outputFileNameTemplate" ref="rawAnalysisOutputFileTemplate"/>

--- a/core/jms-implementation/src/main/resources/spring/jobs/jobFunFam-context.xml
+++ b/core/jms-implementation/src/main/resources/spring/jobs/jobFunFam-context.xml
@@ -36,8 +36,8 @@
           parent="abstractCathFunFamStep">
         <property name="dependsUpon" ref="stepCathFunFamWriteFasta"/>
         <property name="stepDescription" value="Run HMMER3"/>
-        <property name="fullPathToHmmScanBinary" value="${binary.hmmer33.hmmscan.path}"/>
-        <property name="fullPathToHmmsearchBinary" value="${binary.hmmer33.hmmsearch.path}"/>
+        <property name="fullPathToHmmScanBinary" value="${binary.hmmer3.hmmscan.path}"/>
+        <property name="fullPathToHmmsearchBinary" value="${binary.hmmer3.hmmsearch.path}"/>
         <property name="binarySwitches"
                   value="${hmmer3.hmmsearch.switches.gene3d} ${hmmer3.hmmsearch.cpu.switch.gene3d}"/>
         <property name="fullPathToHmmFile" value="${gene3d.hmm.path}"/>
@@ -91,7 +91,7 @@
         <property name="usesFileOutputSwitch" value="true"/>
         <property name="outputFileNameTemplate" ref="rawAnalysisOutputThreeFileTemplate"/>
         <property name="cathResolveHitsOutputFileNameTemplate" ref="rawAnalysisOutputFourFileTemplate"/>
-        <property name="fullPathToHmmsearchBinary" value="${binary.hmmer33.hmmsearch.path}"/>
+        <property name="fullPathToHmmsearchBinary" value="${binary.hmmer3.hmmsearch.path}"/>
         <property name="hmmsearchBinarySwitches" value="${hmmer3.hmmsearch.switches.funfam} ${hmmer3.hmmsearch.cpu.switch.funfam}"/>
         <property name="fullPathToCathResolveBinary" value="${cath.resolve.hits.path}"/>
         <property name="cathResolveBinarySwitches" value="${cath.resolve.hits.switches.funfam}"/>

--- a/core/jms-implementation/src/main/resources/spring/jobs/jobGene3d-context.xml
+++ b/core/jms-implementation/src/main/resources/spring/jobs/jobGene3d-context.xml
@@ -36,8 +36,8 @@
           parent="abstractCathGene3dStep">
         <property name="dependsUpon" ref="stepCathGene3dWriteFasta"/>
         <property name="stepDescription" value="Run HMMER3"/>
-        <property name="fullPathToHmmScanBinary" value="${binary.hmmer33.hmmscan.path}"/>
-        <property name="fullPathToHmmsearchBinary" value="${binary.hmmer33.hmmsearch.path}"/>
+        <property name="fullPathToHmmScanBinary" value="${binary.hmmer3.hmmscan.path}"/>
+        <property name="fullPathToHmmsearchBinary" value="${binary.hmmer3.hmmsearch.path}"/>
         <property name="binarySwitches"
                   value="${hmmer3.hmmsearch.switches.gene3d} ${hmmer3.hmmsearch.cpu.switch.gene3d}"/>
         <property name="fullPathToHmmFile" value="${gene3d.hmm.path}"/>

--- a/core/jms-implementation/src/main/resources/spring/jobs/jobHAMAP-context.xml
+++ b/core/jms-implementation/src/main/resources/spring/jobs/jobHAMAP-context.xml
@@ -39,8 +39,8 @@
           parent="abstractHamapHMMStep">
         <property name="dependsUpon" ref="stepHamapHMMWriteFastaFile"/>
         <property name="stepDescription" value="Run HMMER3"/>
-        <property name="fullPathToHmmsearchBinary" value="${binary.hmmer33.hmmsearch.path}"/>
-        <property name="fullPathToHmmScanBinary" value="${binary.hmmer33.hmmscan.path}"/>
+        <property name="fullPathToHmmsearchBinary" value="${binary.hmmer3.hmmsearch.path}"/>
+        <property name="fullPathToHmmScanBinary" value="${binary.hmmer3.hmmscan.path}"/>
         <property name="singleSeqMode" value="false"/>
         <property name="binarySwitches" value="${hmmer3.hmmsearch.switches.hmmfilter} ${hmmer3.hmmsearch.cpu.switch.hmmfilter}"/>
         <property name="fullPathToHmmFile" value="${hamap.hmm.path}"/>

--- a/core/jms-implementation/src/main/resources/spring/jobs/jobNCBIfam-context.xml
+++ b/core/jms-implementation/src/main/resources/spring/jobs/jobNCBIfam-context.xml
@@ -38,7 +38,7 @@
         <property name="dependsUpon" ref="stepNCBIfamWriteFastaFile"/>
         <property name="stepDescription" value="Run fingerprintscan Binary for selected proteins"/>
         <property name="fullPathToHmmScanBinary" value="${binary.hmmer3.hmmscan.path}"/>
-        <property name="fullPathToHmmsearchBinary" value="${binary.hmmer33.hmmsearch.path}"/>
+        <property name="fullPathToHmmsearchBinary" value="${binary.hmmer3.hmmsearch.path}"/>
         <property name="binarySwitches" value="${hmmer3.hmmsearch.switches.ncbifam} ${hmmer3.hmmsearch.cpu.switch.ncbifam}"/>
         <property name="usesFileOutputSwitch" value="true"/>
         <property name="outputFileNameTemplate" ref="rawAnalysisOutputFileTemplate"/>

--- a/core/jms-implementation/src/main/resources/spring/jobs/jobPIRSF-context.xml
+++ b/core/jms-implementation/src/main/resources/spring/jobs/jobPIRSF-context.xml
@@ -41,8 +41,8 @@
         <property name="dependsUpon" ref="stepPIRSFWriteFasta"/>
         <property name="stepDescription" value="Run hmmer3 Binary for selected proteins"/>
         <property name="forceHmmsearch" value="${pirsf.hmmsearch.force}"/>
-        <property name="fullPathToHmmsearchBinary" value="${binary.hmmer33.hmmsearch.path}"/>
-        <property name="fullPathToHmmScanBinary" value="${binary.hmmer33.hmmscan.path}"/>
+        <property name="fullPathToHmmsearchBinary" value="${binary.hmmer3.hmmsearch.path}"/>
+        <property name="fullPathToHmmScanBinary" value="${binary.hmmer3.hmmscan.path}"/>
         <property name="binarySwitches" value="${hmmer3.hmmsearch.switches.pirsf} ${hmmer3.hmmsearch.cpu.switch.pirsf}"/>
         <property name="fullPathToHmmFile" value="${pirsf.sfhmm.path}"/>
         <property name="fastaFileNameTemplate" ref="fastaFileNameTemplate"/>
@@ -69,7 +69,7 @@
         <!--More specific properties-->
         <property name="perlCommand" value="${perl.command}"/>
         <property name="scriptPath" value="${binary.pirsf.pl.path}"/>
-        <property name="hmmerPath" value="${binary.hmmer33.path}"/>
+        <property name="hmmerPath" value="${binary.hmmer3.path}"/>
         <property name="sfHmmAllPath" value="${pirsf.sfhmm.path}"/>
         <property name="pirsfDatPath" value="${pirsf.dat.path}"/>
         <property name="binarySwitches" value="${pirsf.pl.binary.switches} ${pirsf.pl.binary.cpu.switch}"/>

--- a/core/jms-implementation/src/main/resources/spring/jobs/jobPanther-context.xml
+++ b/core/jms-implementation/src/main/resources/spring/jobs/jobPanther-context.xml
@@ -61,8 +61,8 @@
         <property name="dependsUpon" ref="stepPantherWriteFastaFile"/>
         <property name="stepDescription" value="Run HMMER 3 Binary for selected proteins"/>
         <property name="forceHmmsearch" value="${panther.hmmsearch.force}"/>
-        <property name="fullPathToHmmScanBinary" value="${binary.hmmer33.hmmscan.path}"/>
-        <property name="fullPathToHmmsearchBinary" value="${binary.hmmer33.hmmsearch.path}"/>
+        <property name="fullPathToHmmScanBinary" value="${binary.hmmer3.hmmscan.path}"/>
+        <property name="fullPathToHmmsearchBinary" value="${binary.hmmer3.hmmsearch.path}"/>
         <property name="binarySwitches" value="${hmmer3.hmmsearch.switches.panther} ${hmmer3.hmmsearch.cpu.switch.panther}"/>
         <property name="fullPathToHmmFile" value="${panther.hmm.path}"/>
         <property name="fastaFileNameTemplate" ref="fastaFileNameTemplate"/>

--- a/core/jms-implementation/src/main/resources/spring/jobs/jobPfam-context.xml
+++ b/core/jms-implementation/src/main/resources/spring/jobs/jobPfam-context.xml
@@ -40,8 +40,8 @@
           parent="abstractPfamStep">
         <property name="dependsUpon" ref="stepPfamWriteFastaFile"/>
         <property name="stepDescription" value="Run HMMER 3 Binary for selected proteins"/>
-        <property name="fullPathToHmmScanBinary" value="${binary.hmmer33.hmmscan.path}"/>
-        <property name="fullPathToHmmsearchBinary" value="${binary.hmmer33.hmmsearch.path}"/>
+        <property name="fullPathToHmmScanBinary" value="${binary.hmmer3.hmmscan.path}"/>
+        <property name="fullPathToHmmsearchBinary" value="${binary.hmmer3.hmmsearch.path}"/>
         <property name="binarySwitches" value="${hmmer3.hmmsearch.switches.pfama} ${hmmer3.hmmsearch.cpu.switch.pfama}"/>
         <property name="fullPathToHmmFile" value="${pfam-a.hmm.path}"/>
         <property name="fastaFileNameTemplate" ref="fastaFileNameTemplate"/>

--- a/core/jms-implementation/src/main/resources/spring/jobs/jobSFLD-context.xml
+++ b/core/jms-implementation/src/main/resources/spring/jobs/jobSFLD-context.xml
@@ -48,8 +48,8 @@
         <property name="dependsUpon" ref="stepSFLDWriteFastaFile"/>
         <property name="stepDescription" value="Run hmmer3 Binary for selected proteins"/>
         <property name="forceHmmsearch" value="${sfld.hmmsearch.force}"/>
-        <property name="fullPathToHmmsearchBinary" value="${binary.hmmer33.hmmsearch.path}"/>
-        <property name="fullPathToHmmScanBinary" value="${binary.hmmer33.hmmscan.path}"/>
+        <property name="fullPathToHmmsearchBinary" value="${binary.hmmer3.hmmsearch.path}"/>
+        <property name="fullPathToHmmScanBinary" value="${binary.hmmer3.hmmscan.path}"/>
         <property name="binarySwitches" value="${hmmer3.hmmsearch.switches.sfld} ${hmmer3.hmmsearch.cpu.switch.sfld}"/>
         <property name="fullPathToHmmFile" value="${sfld.hmm.path}"/>
         <property name="fastaFileNameTemplate" ref="fastaFileNameTemplate"/>

--- a/core/jms-implementation/src/main/resources/spring/jobs/jobSuperFamily-context.xml
+++ b/core/jms-implementation/src/main/resources/spring/jobs/jobSuperFamily-context.xml
@@ -42,7 +42,7 @@
         -->
         <property name="dependsUpon" ref="stepSuperFamilyWriteFastaFile"/>
         <property name="stepDescription" value="Run HMMER3"/>
-        <property name="fullPathToHmmsearchBinary" value="${binary.hmmer33.hmmscan.path}"/>
+        <property name="fullPathToHmmsearchBinary" value="${binary.hmmer3.hmmscan.path}"/>
         <property name="binarySwitches" value="${hmmer3.hmmsearch.switches.superfamily} ${hmmer3.hmmsearch.cpu.switch.superfamily}"/>
         <property name="fullPathToHmmFile" value="${superfamily.hmm.path}"/>
         <property name="usesFileOutputSwitch" value="true"/>

--- a/core/jms-implementation/support-mini-x86-32/interproscan.properties
+++ b/core/jms-implementation/support-mini-x86-32/interproscan.properties
@@ -14,8 +14,7 @@ perl.command=perl
 python3.command=python3
 
 # Binary file locations (required for setup.py)
-binary.hmmer3.path=${bin.directory}/hmmer/hmmer3/3.1b1
-binary.hmmer33.path=${bin.directory}/hmmer/hmmer3/3.3
+binary.hmmer3.path=${bin.directory}/hmmer/hmmer3/3.3
 
 ####################################
 # Member databases HMMs

--- a/core/jms-implementation/support-mini-x86-32/setup.py
+++ b/core/jms-implementation/support-mini-x86-32/setup.py
@@ -80,10 +80,7 @@ def main():
     ignore = {"binary.tmhmm.path", "funfam.hmm.path", "smart.hmm.path"}
     for key, path in properties.items():
         if "hmm.path" in key and key not in ignore:
-            if key.startswith(("sfld", "superfamily")):
-                bin_key = "binary.hmmer3.path"
-            else:
-                bin_key = "binary.hmmer33.path"
+            bin_key = "binary.hmmer3.path"
 
             if os.path.isfile(path):
                 hmmfiles = [path]


### PR DESCRIPTION
Superfamily and SSD original data files (HMM profiles) contain duplicated NAME / ACC values.
This was not an issue in hmmer 3.1b2 but is in hmmer 3.3+.
For that reason the 2 hmmer versions where in use by interproscan, but the problem would arise when using containers due to only a recent hmmer binary being used.
The source data files where edited to in the case of Superfamily include virtual versions to the ACC (1234.5), and in the case on SFLD the NAME (name$2). Interproscan will ignore from the ./$ to maintain backwards consistency.
Interproscan now can use hmmer 3.3 for all member databases.

https://www.ebi.ac.uk/panda/jira/browse/IBU-10729