### PR TITLE
Representative families

### DIFF
--- a/core/management/src/main/java/uk/ac/ebi/interpro/scan/management/model/implementations/PrepareForOutputStep.java
+++ b/core/management/src/main/java/uk/ac/ebi/interpro/scan/management/model/implementations/PrepareForOutputStep.java
@@ -928,7 +928,7 @@ public class PrepareForOutputStep extends Step {
                 String type = (String) value.get("type");
 
                 if (type != null) {
-                    typesMap.put(accession, type);
+                    typesMap.put(accession, type.toUpperCase());
                 }
 
                 Map<String, Object> representative = (Map<String, Object>) value.get("representative");

--- a/core/model/src/main/java/uk/ac/ebi/interpro/scan/model/Signature.java
+++ b/core/model/src/main/java/uk/ac/ebi/interpro/scan/model/Signature.java
@@ -47,7 +47,7 @@ import java.util.*;
         @Index(name = "SIGNATURE_TYPE_IDX", columnList = "TYPE"),
         @Index(name = "SIGNATURE_MD5_IDX", columnList = "MD5")
 })
-@JsonIgnoreProperties({"hibernateLazyInitializer", "handler", "updated", "created", "id", "crossReferences", "abstract", "comment", "md5", "deprecatedAccessions", "type"}) // IBU-4703: "abstract", "comment", "md5" and "type" are never populated
+@JsonIgnoreProperties({"hibernateLazyInitializer", "handler", "updated", "created", "id", "crossReferences", "abstract", "comment", "md5", "deprecatedAccessions"})
 public class Signature implements Serializable {
 
     @Transient
@@ -371,7 +371,7 @@ public class Signature implements Serializable {
         return type;
     }
 
-    private void setType(String type) {
+    public void setType(String type) {
         this.type = type;
     }
 


### PR DESCRIPTION
In the same way as representative domains, representative families are now selected and reported in XML/JSON output.
The signature type as reported in the entries.json file is now included in the XML/JSON output.