### PR TITLE
MobiDB-lite sequence features fix

### DIFF
--- a/core/io/src/main/java/uk/ac/ebi/interpro/scan/io/match/mobidb/MobiDBMatchParser.java
+++ b/core/io/src/main/java/uk/ac/ebi/interpro/scan/io/match/mobidb/MobiDBMatchParser.java
@@ -97,7 +97,7 @@ public class MobiDBMatchParser implements MatchParser<MobiDBRawMatch> {
                     int locationEnd = Integer.parseInt(matcher.group(3));
                     String feature = matcher.group(4).trim();
                     if (feature.equals("-")) {
-                        feature = "";
+                        feature = null;
                     }
 
                     matches.add(new MobiDBRawMatch(sequenceIdentifier, "mobidb-lite",

--- a/core/io/src/main/java/uk/ac/ebi/interpro/scan/io/match/writer/ProteinMatchesTSVProResultWriter.java
+++ b/core/io/src/main/java/uk/ac/ebi/interpro/scan/io/match/writer/ProteinMatchesTSVProResultWriter.java
@@ -118,8 +118,9 @@ public class ProteinMatchesTSVProResultWriter extends ProteinMatchesResultWriter
                             mappingFields.add(Integer.toString(pantherLocation.getEnvelopeEnd()));
                         } else if (location instanceof SuperFamilyHmmer3Match.SuperFamilyHmmer3Location) {
                             mappingFields.add(Integer.toString(((SuperFamilyHmmer3Match.SuperFamilyHmmer3Location) location).getHmmLength()));
-                        } else if (location instanceof MobiDBMatch.MobiDBLocation){
-                            mappingFields.add(((MobiDBMatch.MobiDBLocation) location).getSequenceFeature());
+                        } else if (location instanceof MobiDBMatch.MobiDBLocation) {
+                            MobiDBMatch.MobiDBLocation mobiDBLocation = (MobiDBMatch.MobiDBLocation) location;
+                            mappingFields.add(Objects.requireNonNullElse(mobiDBLocation.getSequenceFeature(), "-"));
                         }
 
                         if (location instanceof Hmmer3Match.Hmmer3Location) {

--- a/core/model/src/main/java/uk/ac/ebi/interpro/scan/model/MobiDBMatch.java
+++ b/core/model/src/main/java/uk/ac/ebi/interpro/scan/model/MobiDBMatch.java
@@ -22,9 +22,6 @@ import java.util.Set;
 @Table(name = "mobidb_match")
 @XmlType(name = "MobiDBMatchType")
 public class MobiDBMatch extends Match<MobiDBMatch.MobiDBLocation> {
-
-
-
     protected MobiDBMatch() {
     }
 
@@ -85,6 +82,7 @@ public class MobiDBMatch extends Match<MobiDBMatch.MobiDBLocation> {
             final MobiDBLocation f = (MobiDBLocation) o;
             return new EqualsBuilder()
                     .appendSuper(super.equals(o))
+                    .append(getSequenceFeature(), f.getSequenceFeature())
                     .isEquals();
         }
 
@@ -92,6 +90,7 @@ public class MobiDBMatch extends Match<MobiDBMatch.MobiDBLocation> {
         public int hashCode() {
             return new HashCodeBuilder(43, 79)
                     .appendSuper(super.hashCode())
+                    .append(getSequenceFeature())
                     .toHashCode();
         }
 

--- a/core/model/src/main/java/uk/ac/ebi/interpro/scan/model/raw/MobiDBRawMatch.java
+++ b/core/model/src/main/java/uk/ac/ebi/interpro/scan/model/raw/MobiDBRawMatch.java
@@ -1,9 +1,9 @@
 package uk.ac.ebi.interpro.scan.model.raw;
 
-import uk.ac.ebi.interpro.scan.model.SignalPOrganismType;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
 import uk.ac.ebi.interpro.scan.model.SignatureLibrary;
 
-import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Index;
 import javax.persistence.Table;
@@ -57,5 +57,26 @@ public class MobiDBRawMatch extends RawMatch implements Serializable {
 
     public void setDescription(String description) {
         this.description = description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (!(o instanceof MobiDBRawMatch))
+            return false;
+        final MobiDBRawMatch m = (MobiDBRawMatch) o;
+        return new EqualsBuilder()
+                .appendSuper(super.equals(o))
+                .append(this.description, m.description)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(53, 51)
+                .appendSuper(super.hashCode())
+                .append(this.getDescription())
+                .toHashCode();
     }
 }

--- a/core/persistence/src/main/java/uk/ac/ebi/interpro/scan/persistence/MobiDBFilteredMatchDAO.java
+++ b/core/persistence/src/main/java/uk/ac/ebi/interpro/scan/persistence/MobiDBFilteredMatchDAO.java
@@ -80,13 +80,6 @@ class MobiDBFilteredMatchDAO extends FilteredMatchDAOImpl<MobiDBRawMatch, MobiDB
         return new MobiDBMatch.MobiDBLocation(rawMatch.getLocationStart(), rawMatch.getLocationEnd(), rawMatch.getDescription());
     }
 
-    private MobiDBMatch buildMatch(Signature signature, MobiDBRawMatch rawMatch) {
-        MobiDBMatch.MobiDBLocation location = new MobiDBMatch.MobiDBLocation(
-                rawMatch.getLocationStart(),
-                rawMatch.getLocationEnd(), rawMatch.getDescription());
-        return new MobiDBMatch(signature, rawMatch.getModelId(), Collections.singleton(location));
-    }
-
     /**
      * This method retrieves the persisted Signatures for all of the
      * Disordered featues.  If any of them they do not exist in the database, this
@@ -104,9 +97,8 @@ class MobiDBFilteredMatchDAO extends FilteredMatchDAOImpl<MobiDBRawMatch, MobiDB
         query.setParameter("release", release);
         @SuppressWarnings("unchecked") List<Signature> retrievedSignatures = query.getResultList();
 
-        if (retrievedSignatures.size() == 0) {
+        if (retrievedSignatures.isEmpty()) {
             // The Signature record does not exist yet, so create it.
-
             entityManager.persist(signature);
             return signature;
         } else if (retrievedSignatures.size() > 1) {


### PR DESCRIPTION
MobiDB-lite reports predicted intrinsically disordered regions (IDR), and sequence features, which are the disorder state of some subregions.

However, in rare cases a sequence feature can span over the full length of the disordered region, e.g.

| Sequence | Start | End | State |
|--------------|----------|------|--------|
| sequence-1 |	1	| 28 |	- |
| sequence-1 |1 | 28 | Polar |
|sequence-2 |	456 |	515 |	- |
|sequence-2	|456	|515	|Low complexity |

_(Annotations with `State` equal to `-` are "normal" predicted IDR)_

This is not supported by InterProScan 5 at the moment, so only one match is reported. This PR addresses this so both the IDR and the sequence feature are reported.
